### PR TITLE
0.2.0.5: `identical_partables()` now correctly  ignores `ustart` for …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: modelbpp
 Title: Model BIC Posterior Probability
-Version: 0.2.0.4
+Version: 0.2.0.5
 Authors@R:
     c(person(given = "Shu Fai",
              family = "Cheung",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# modelbpp 0.2.0.4
+# modelbpp 0.2.0.5
 
 ## Miscellaneous
 
@@ -22,6 +22,10 @@
 
 - `gen_models()` now correctly handles
   `cross_add = NULL`. (0.2.0.3)
+
+- `identical_partables()` now correctly
+  ignores `ustart` for free parameters.
+  (0.2.0.5)
 
 # modelbpp 0.2.0
 

--- a/R/partables_helpers.R
+++ b/R/partables_helpers.R
@@ -105,8 +105,8 @@ identical_partables <- function(object1,
       }
     if (!is.null(tmp1$ustart) &&
         !is.null(tmp2$ustart)) {
-        tmp1u <- tmp1[which(tmp1$ustart > 0), ]
-        tmp2u <- tmp2[which(tmp2$ustart > 0), ]
+        tmp1u <- tmp1[which((tmp1$ustart > 0) & (tmp1$free == 0)), ]
+        tmp2u <- tmp2[which((tmp2$ustart > 0) & (tmp2$free == 0)), ]
         if (!identical(tmp1u$start,
                        tmp2u$start)) {
             return(FALSE)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # modelbpp: Model BIC Posterior Probability <img src="man/figures/logo.png" align="right" />
 
-(Version 0.2.0.4 updated on 2026-03-31, [release history](https://sfcheung.github.io/modelbpp/news/index.html))
+(Version 0.2.0.5 updated on 2026-03-31, [release history](https://sfcheung.github.io/modelbpp/news/index.html))
 
 This package is for assessing model uncertainty in structural
 equation modeling (SEM) by the BIC posterior


### PR DESCRIPTION
…free parameters.

tests and checks passed.